### PR TITLE
Check for invalid field and add CSS hook

### DIFF
--- a/contact-form-7-dynamic-text-extension.php
+++ b/contact-form-7-dynamic-text-extension.php
@@ -76,7 +76,7 @@ function wpcf7_dynamictext_shortcode_handler( $tag ) {
 	$maxlength_att = '';
 	$tabindex_att = '';
 
-	$class_att .= ' wpcf7-text';
+	$class_att .= ' wpcf7-text wpcf7-form-control';
 
 	if ( 'dynamictext*' == $type )
 		$class_att .= ' wpcf7-validates-as-required';
@@ -97,6 +97,11 @@ function wpcf7_dynamictext_shortcode_handler( $tag ) {
 
 		}
 	}
+
+	$validation_error = wpcf7_get_validation_error( $tag->name );
+	
+	if ( $validation_error )
+		$class_att .= ' wpcf7-not-valid';
 
 	if ( $id_att )
 		$atts .= ' id="' . trim( $id_att ) . '"';


### PR DESCRIPTION
Currently, you can't setup a field using `[dynamictext*]` and use the same CSS hooks you'd use for normal `[text*]` field validations.  Typically there's a class of `wpcf7-not-valid` added to `[text*]` fields in CF7 on the frontend.  I've added a function that checks for an error and if there is one, appends that class to the HTML output for that field.

I've also added a base CSS class to the output element so that, by default it has classes of `wpcf7-text` and `wpcf7-form-control` because I believe that is what CF7 outputs by default.   I realize we might be able to use a filter but I constantly run into this issue when setting up websites using this plugin and since CF7 uses that as a default class, maybe this plugin should too.  I use some JS that looks for some CF7 fields and it's easier to use `$('.wpcf7-form-control')` if I want to target all form elements including the dynamic text fields.
