### PR TITLE
Check if class "WPCF7_TagGenerator" exists

### DIFF
--- a/contact-form-7-dynamic-text-extension.php
+++ b/contact-form-7-dynamic-text-extension.php
@@ -164,6 +164,9 @@ if ( is_admin() ) {
 }
 
 function wpcf7dtx_add_tag_generator_dynamictext() {
+	if ( ! class_exists( 'WPCF7_TagGenerator' ) ) {
+		return;		
+	}	
 
 	$tag_generator = WPCF7_TagGenerator::get_instance();
 	$tag_generator->add( 'dynamictext', __( 'dynamic text', 'contact-form-7' ),


### PR DESCRIPTION
People can lock themselves out of the WordPress admin area if the "Dynamic Text Extension" plugin is active but "Contact Form 7" is not. This can easily happen by accident, for example if both plugins are currently active and you want to deactivate them both, but you start by deactivating "Contact Form 7".

In this case, they would get the error message

```
PHP Fatal error:  Class 'WPCF7_TagGenerator' not found in /data/wordpress/www/wp-content/plugins/contact-form-7-dynamic-text-extension/contact-form-7-dynamic-text-extension.php on line 168
```

We can easily prevent this by checking if the class `WPCF7_TagGenerator` exists.
