### PR TITLE
Fix for CF7 not fetching value and replace deprecated get_currentuserinfo with wp_get_current_user

### DIFF
--- a/contact-form-7-dynamic-text-extension.php
+++ b/contact-form-7-dynamic-text-extension.php
@@ -376,23 +376,20 @@ function cf7_get_custom_field($atts){
 add_shortcode('CF7_get_custom_field', 'cf7_get_custom_field');
 
 /* Insert information about the current user
- * New in 1.0.4 
- * See http://codex.wordpress.org/Function_Reference/get_currentuserinfo 
+ * See https://codex.wordpress.org/Function_Reference/wp_get_current_user 
  */
 function cf7_get_current_user($atts){
 	extract(shortcode_atts(array(
 		'key' => 'user_login',
 	), $atts));
-
-	global $current_user;
-	get_currentuserinfo();
-
-	$val = $current_user->$key;
+	$val = '';
+	if( is_user_logged_in() ) {
+		$current_user = wp_get_current_user();
+		$val = $current_user->$key;
+	}
 	return $val;
 }
 add_shortcode('CF7_get_current_user', 'cf7_get_current_user');
-
-
 
 function cf7_get_referrer( $atts ){
 	return isset( $_SERVER['HTTP_REFERER'] ) ? $_SERVER['HTTP_REFERER'] : '';

--- a/contact-form-7-dynamic-text-extension.php
+++ b/contact-form-7-dynamic-text-extension.php
@@ -275,13 +275,11 @@ function wpcf7dtx_tag_generator_dynamictext( $contact_form , $args = '' ){
  *****************************************************/
 
 /* Insert a $_GET variable */
-function cf7_get($atts){
-	extract(shortcode_atts(array(
-		'key' => 0,
-	), $atts));
+function cf7_get( $atts ){
+	$keys = array_keys( $atts );
 	$value = '';
-	if( isset( $_GET[$key] ) ){
-		$value = urldecode($_GET[$key]);
+	if( isset( $_GET[$keys[0]] ) ){
+		$value = urldecode( $_GET[$keys[0]] );
 	}
 	return $value;
 }

--- a/contact-form-7-dynamic-text-extension.php
+++ b/contact-form-7-dynamic-text-extension.php
@@ -391,6 +391,22 @@ function cf7_get_current_user($atts){
 }
 add_shortcode('CF7_get_current_user', 'cf7_get_current_user');
 
+/* Insert current user email address
+ * See http://codex.wordpress.org/Function_Reference/wp_get_current_user  
+ */
+function cf7_get_current_user_email($atts){
+	extract(shortcode_atts(array(
+		'key' => 'user_email',
+	), $atts));
+	$val = '';
+	if( is_user_logged_in() ) {
+		$current_user = wp_get_current_user();
+		$val = $current_user->$key;
+	}
+	return $val;
+}
+add_shortcode('CF7_get_current_user_email', 'cf7_get_current_user_email');
+
 function cf7_get_referrer( $atts ){
 	return isset( $_SERVER['HTTP_REFERER'] ) ? $_SERVER['HTTP_REFERER'] : '';
 }


### PR DESCRIPTION
CF7_GET doesn't get the key, updated it to work.

get_currentuserinfo() is deprecated, replaced with wp_get_current_user().

Added new shortcode CF7_get_current_user_email
