### PR TITLE
Allow retrieval of ID key in get_post_var shortcode

### DIFF
--- a/contact-form-7-dynamic-text-extension.php
+++ b/contact-form-7-dynamic-text-extension.php
@@ -324,6 +324,9 @@ function cf7_get_post_var($atts){
 		case 'title':
 			$key = 'post_title';
 			break;
+		default:
+			$key = 'ID';
+			break;			
 	}
 	
 	global $post;


### PR DESCRIPTION
Customize the function to return $post->ID whenever requested or if an unrecognized key is being used.